### PR TITLE
Create a new 'ots-distribution' module that provides a deduplicated uber JAR for OTS

### DIFF
--- a/ots-distribution/pom.xml
+++ b/ots-distribution/pom.xml
@@ -1,0 +1,96 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.opentrafficsim</groupId>
+    <artifactId>ots</artifactId>
+    <version>1.7.5</version>
+  </parent>
+
+  <artifactId>ots-distribution</artifactId>
+  <name>OpenTrafficSim Distribution Module</name>
+  <description>Creates an uber jar, that can be easily distributed</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-base</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-core</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-kpi</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-road</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-trafficcontrol</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-animation</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-draw</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-swing</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-web</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-sim0mq</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-sim0mq-kpi</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-sim0mq-swing</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.opentrafficsim</groupId>
+        <artifactId>ots-parser-xml</artifactId>
+        <version>${ots.version}</version>
+      </dependency>
+  </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>ots-parser-xml</module>
     <module>ots-demo</module>
     <module>ots-editor</module>
+    <module>ots-distribution</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
With the introduction of the shade maven plugin (fat jars), the module JARs
also include all dependencies of each module. Because each OTS module is built
independently, this means that the dependencies are duplicated across all
modules and the combined module size exceeds 100MB. As PyPi limits distributions
to 100MB, OTS cannot be distributed on PyPi with the current setup.

Therefore, this adds a separate 'ots-distribution' which combines all OTS
modules and their dependencies. With the deduplication applied,
a distribution size of roughly 15MB is achieved.

To stay compatible with the current setup in cr-ots-interface, the shade plugin is still applied to all modules and to the new ots-distribution module.